### PR TITLE
fix typo on servicesScope URI

### DIFF
--- a/nsxvapiv616.raml
+++ b/nsxvapiv616.raml
@@ -528,7 +528,7 @@ securitySchemes:
       body:
         application/xml:
           schema: nsxControllerPasswordUpdate
-/2.0/services/application/{scopeId}: # PDF page 95
+/2.0/services/application/scope/{scopeId}: # PDF page 95
   displayName: servicesScope
   description: Working with services on a scope
   uriParameters:


### PR DESCRIPTION
servicesScope was missing /scope/ from it's URI page 95 of http://pubs.vmware.com/NSX-61/topic/com.vmware.ICbase/PDF/nsx_61_api.pdf
