### PR TITLE
Fix nwfabricConfigCreate example

### DIFF
--- a/nsxvapi.raml
+++ b/nsxvapi.raml
@@ -3962,7 +3962,7 @@ securitySchemes:
 
             <!-- * Configure VXLAN with LACPv2
 
-            POST /api/2.0/nwfabric/configure -->
+            POST /api/2.0/nwfabric/configure
 
             <nwFabricFeatureConfig>
               <featureId>com.vmware.vshield.nsxmgr.vxlan</featureId>
@@ -3987,7 +3987,7 @@ securitySchemes:
                   <uplinkPortName>LAG NAME</uplinkPortName>
                 </configSpec>
               </resourceConfig>
-            </nwFabricFeatureConfig>
+            </nwFabricFeatureConfig> -->
 
             <!-- * Reset Communication
 
@@ -3999,6 +3999,16 @@ securitySchemes:
                 <resourceId>resourceId</resourceId>
               </resourceConfig>
             </nwFabricFeatureConfig> -->
+
+            <!-- * Basic Example -->
+            <nwFabricFeatureConfig>
+              <featureId></featureId>
+              <resourceConfig>
+                <resourceId></resourceId>
+                <configSpec></configSpec>
+              </resourceConfig>
+            </nwFabricFeatureConfig>
+
           schema: nwFabricConfig
       queryParameters:
         action:


### PR DESCRIPTION
When Using nwfabricConfigCreate body example, nsxramlclient does not get body example as expected.

* Modifing comment out scope of "Configure VXLAN with LACPv2".
* Adding basic example.