### PR TITLE
Nsxansible regression check

### DIFF
--- a/nsxvapi.raml
+++ b/nsxvapi.raml
@@ -1057,8 +1057,6 @@ securitySchemes:
             <description>Web tier network</description>
             <tenantId>virtual wire tenant</tenantId>
             <controlPlaneMode>UNICAST_MODE</controlPlaneMode>
-            <!-- This is a nice little comment -->
-            ...
             <guestVlanAllowed>false</guestVlanAllowed>
           </virtualWireCreateSpec>
         schema: logicalSwitchCreate

--- a/nsxvapi.raml
+++ b/nsxvapi.raml
@@ -1057,6 +1057,8 @@ securitySchemes:
             <description>Web tier network</description>
             <tenantId>virtual wire tenant</tenantId>
             <controlPlaneMode>UNICAST_MODE</controlPlaneMode>
+            <!-- This is a nice little comment -->
+            ...
             <guestVlanAllowed>false</guestVlanAllowed>
           </virtualWireCreateSpec>
         schema: logicalSwitchCreate
@@ -2266,12 +2268,12 @@ securitySchemes:
         possible valid elements that can be added to the
         service.
 /2.0/services/ipam/pools:
-  displayName: ipPools
+  displayName: ipPoolBaseUri
   description: |
     Working with IP Pool Grouping Objects
     ========
   /scope/{scopeId}:
-    displayName: ipPoolScope
+    displayName: ipPools
     description: |
       Working with IP Pools on a Specific Scope
       -----
@@ -4152,16 +4154,6 @@ securitySchemes:
                     <vlanId>0</vlanId>
                     <vmknicCount>1</vmknicCount>
                     <ipPoolId>IPADDRESSPOOL ID</ipPoolId>
-                </configSpec>
-              </resourceConfig>
-              <resourceConfig>
-                <resourceId>DVS MOID</resourceId>
-                <configSpec class="vdsContext">
-                  <switch>
-                      <objectId>DVS MOID</objectId>
-                  </switch>
-                  <mtu>1600</mtu>
-                  <teaming>ETHER_CHANNEL</teaming>
                 </configSpec>
               </resourceConfig>
             </nwFabricFeatureConfig> 


### PR DESCRIPTION
Sending a pull request with changes I'd like to get reverted in develop before it merges. Those two changes are breaking the current nsxansible module code, and changing the nsxansible code to ignore those changes creates too much unnecessary work in updating code in various projects.

For the ipPools changes, as long as the displayname of the 'scope' resource stays 'ipPools' it's fine. The baseURI can be named whatever it needs to be named.

Thanks!